### PR TITLE
Fix qp_decode error handling =3D ('=') sequences

### DIFF
--- a/R/qp.r
+++ b/R/qp.r
@@ -28,7 +28,7 @@ qp_after <- c("", "\001", "\002", "\003", "\004", "\005", "\006", "\a", "\b", "\
              "\025", "\026", "\027", "\030", "\031", "\032", "\033", "\034", "\035",
              "\036", "\037", " ", "!", "\"", "#", "$", "%", "&", "'", "(", ")", "*", "+",
              ",", "-", ".", "/", "0", "1", "2", "3", "4", "5", "6", "7", "8", "9", ":",
-             ";", "<", "=", ">", "?", "@", "A", "B", "C", "D", "E", "F", "G", "H", "I",
+             ";", "<", "=3D", ">", "?", "@", "A", "B", "C", "D", "E", "F", "G", "H", "I",
              "J", "K", "L", "M", "N", "O", "P", "Q", "R", "S", "T", "U", "V", "W", "X",
              "Y", "Z", "[", "\\", "]", "^", "_", "`", "a", "b", "c", "d", "e", "f", "g",
              "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r", "s", "t", "u", "v",
@@ -54,5 +54,6 @@ qp_after <- c("", "\001", "\002", "\003", "\004", "\005", "\006", "\a", "\b", "\
 #' @return vector of decoded strings
 #' @export
 qp_decode <- function(x) {
-  stringi::stri_replace_all_fixed(x, qp_before, qp_after, vectorize_all=FALSE)
+  x <- stringi::stri_replace_all_fixed(x, qp_before, qp_after, vectorize_all=FALSE)
+  stringi::stri_replace_all_fixed(x, '=3D', '=', vectorize_all=FALSE)
 }


### PR DESCRIPTION
Where there is a Quoted-Printable encoded equals sign (`=3D`) followed by two characters which can be interpretable as a hex digit from \x3E upwards, `qp_decode` is doing a double decode, resulting in incorrect output (and sometimes invalid UTF-8).

For example, with the strings '=3D40' (which should decode to '=40') and '=3DAA' ('=AA'):
```{r}
> library(hrbrmisc)
Loading required package: fastmatch
> gp_decode('=3D40')
[1] "@"
> qp_decode('=3DAA')
[1] "\xaa"
> validUTF8(qp_decode('=3DAA'))
[1] FALSE
```
This patch delays decoding of '=3D' to a second pass, to stop the resulting '='s being interpreted as the start of new escape sequences.